### PR TITLE
Add #include "mgos.h" to work with later versions of mos

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "mgos.h"
 #include "mgos_arduino_ssd1306.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes: https://github.com/OffGridNetworks/mos-esp32-oled/issues/1

I hit the same issue and the commented solution fixed it for me so here's a PR for future folks.

PS. Thanks for your efforts, this is a great starter project for the Heltec Wifi_Kit_32 board. 